### PR TITLE
.gitignore for setup.py's output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+/*.egg-info/


### PR DESCRIPTION
Add .gitignore for ignoring output of setup.py (e.g. dist, build, egg-info directories).
