### PR TITLE
Add notify models + context from original project

### DIFF
--- a/notification/admin.py
+++ b/notification/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from notification.models import NoticeType, NoticeSetting, NoticeQueueBatch
+from notification.models import NoticeType, NoticeSetting, Notice, NoticeQueueBatch
 
 
 class NoticeTypeAdmin(admin.ModelAdmin):
@@ -11,6 +11,11 @@ class NoticeSettingAdmin(admin.ModelAdmin):
     list_display = ["id", "user", "notice_type", "medium", "send"]
 
 
+class NoticeAdmin(admin.ModelAdmin):
+    list_display = ["message", "recipient", "sender", "notice_type", "added", "unseen", "archived"]
+
+
 admin.site.register(NoticeQueueBatch)
 admin.site.register(NoticeType, NoticeTypeAdmin)
 admin.site.register(NoticeSetting, NoticeSettingAdmin)
+admin.site.register(Notice, NoticeAdmin)

--- a/notification/backends/email.py
+++ b/notification/backends/email.py
@@ -40,3 +40,9 @@ class EmailBackend(backends.BaseBackend):
         }, context)
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [recipient.email])
+        from notification import models as notification
+        notification.Notice.objects.create(recipient=recipient,
+                                           notice_type=notice_type,
+                                           sender=sender,
+                                           message=ugettext(notice_type.display),
+                                           on_site=True)

--- a/notification/context_processors.py
+++ b/notification/context_processors.py
@@ -1,0 +1,10 @@
+from notification.models import Notice
+
+
+def notification(request):
+    if request.user.is_authenticated():
+        return {
+            "notice_unseen_count": Notice.objects.unseen_count_for(request.user, on_site=True),
+        }
+    else:
+        return {}

--- a/notification/models.py
+++ b/notification/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import base64
+import datetime
 
 from django.db import models
 from django.db.models.query import QuerySet
@@ -11,6 +12,8 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language, activate
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.six.moves import cPickle as pickle  # pylint: disable-msg=F
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
 
 from .compat import AUTH_USER_MODEL
 
@@ -106,6 +109,96 @@ class NoticeSetting(models.Model):
             return setting
 
 
+class NoticeManager(models.Manager):
+
+    def notices_for(self, user, archived=False, unseen=None, on_site=None, sent=False):
+        """
+        returns Notice objects for the given user.
+
+        If archived=False, it only include notices not archived.
+        If archived=True, it returns all notices for that user.
+
+        If unseen=None, it includes all notices.
+        If unseen=True, return only unseen notices.
+        If unseen=False, return only seen notices.
+        """
+        if sent:
+            lookup_kwargs = {"sender": user}
+        else:
+            lookup_kwargs = {"recipient": user}
+        qs = self.filter(**lookup_kwargs)
+        if not archived:
+            self.filter(archived=archived)
+        if unseen is not None:
+            qs = qs.filter(unseen=unseen)
+        if on_site is not None:
+            qs = qs.filter(on_site=on_site)
+        return qs
+
+    def unseen_count_for(self, recipient, **kwargs):
+        """
+        returns the number of unseen notices for the given user but does not
+        mark them seen
+        """
+        return self.notices_for(recipient, unseen=True, **kwargs).count()
+
+    def received(self, recipient, **kwargs):
+        """
+        returns notices the given recipient has recieved.
+        """
+        kwargs["sent"] = False
+        return self.notices_for(recipient, **kwargs)
+
+    def sent(self, sender, **kwargs):
+        """
+        returns notices the given sender has sent
+        """
+        kwargs["sent"] = True
+        return self.notices_for(sender, **kwargs)
+
+
+class Notice(models.Model):
+
+    recipient = models.ForeignKey(User, related_name="recieved_notices", verbose_name=_("recipient"))
+    sender = models.ForeignKey(User, null=True, related_name="sent_notices", verbose_name=_("sender"))
+    message = models.TextField(_("message"))
+    notice_type = models.ForeignKey(NoticeType, verbose_name=_("notice type"))
+    added = models.DateTimeField(_("added"), default=datetime.datetime.now)
+    unseen = models.BooleanField(_("unseen"), default=True)
+    archived = models.BooleanField(_("archived"), default=False)
+    on_site = models.BooleanField(_("on site"))
+
+    objects = NoticeManager()
+
+    def __unicode__(self):
+        return self.message
+
+    def archive(self):
+        self.archived = True
+        self.save()
+
+    def is_unseen(self):
+        """
+        returns value of self.unseen but also changes it to false.
+
+        Use this in a template to mark an unseen notice differently the first
+        time it is shown.
+        """
+        unseen = self.unseen
+        if unseen:
+            self.unseen = False
+            self.save()
+        return unseen
+
+    class Meta:
+        ordering = ["-added"]
+        verbose_name = _("notice")
+        verbose_name_plural = _("notices")
+
+    def get_absolute_url(self):
+        return reverse("notification_notice", args=[str(self.pk)])
+
+
 class NoticeQueueBatch(models.Model):
     """
     A queued notice.
@@ -142,7 +235,7 @@ def send_now(users, label, extra_context=None, sender=None):
     notification.send(user, "friends_invite_sent", {
         "spam": "eggs",
         "foo": "bar",
-    )
+    })
     """
     sent = False
     if extra_context is None:


### PR DESCRIPTION
The original project stored notification and had few features important for this project.
https://github.com/Star2Billing/django-notification/tree/master/notification

This PR is to open a discussion how to add them back properly.
