### PR TITLE
make medium use a label as identifier

### DIFF
--- a/notification/backends/__init__.py
+++ b/notification/backends/__init__.py
@@ -38,8 +38,9 @@ def load_backends():
             )
         # add the backend label and an instantiated backend class to the
         # backends list.
-        backend_instance = getattr(mod, backend_class)(medium_id, spam_sensitivity)
-        backends.append(((medium_id, label), backend_instance))
+        backend_instance = getattr(mod, backend_class)(label, spam_sensitivity)
+        backends.append(((label, label), backend_instance))
+
     return dict(backends)
 
 
@@ -49,5 +50,5 @@ def load_media_defaults(backends):
     for key, backend in backends.items():
         # key is a tuple (medium_id, backend_label)
         media.append(key)
-        defaults[key[0]] = backend.spam_sensitivity
+        defaults[key[1]] = backend.spam_sensitivity
     return media, defaults

--- a/notification/models.py
+++ b/notification/models.py
@@ -87,7 +87,7 @@ class NoticeSetting(models.Model):
 
     user = models.ForeignKey(AUTH_USER_MODEL, verbose_name=_("user"))
     notice_type = models.ForeignKey(NoticeType, verbose_name=_("notice type"))
-    medium = models.CharField(_("medium"), max_length=1, choices=NOTICE_MEDIA)
+    medium = models.CharField(_("medium"), max_length=100, choices=NOTICE_MEDIA)
     send = models.BooleanField(_("send"))
 
     class Meta:

--- a/notification/tests/__init__.py
+++ b/notification/tests/__init__.py
@@ -4,5 +4,5 @@ from ..models import NOTICE_MEDIA
 def get_backend_id(backend_name):
     for bid, bname in NOTICE_MEDIA:
         if bname == backend_name:
-            return bid
+            return bname
     return None


### PR DESCRIPTION
fixes #21 this commit uses the backends label from NOTIFICATION_BACKENDS setting
for easier to rearrange backends

for upgrades, you may have to write a custom alter statement to turn integers into varchars and then change the labels in your NOTIFICATION_BACKENDS to the string equivalent of the order