### PR TITLE
update notices_url and message

### DIFF
--- a/pinax/notifications/templates/pinax/notifications/email_body.txt
+++ b/pinax/notifications/templates/pinax/notifications/email_body.txt
@@ -1,6 +1,6 @@
-{% load i18n %}{% url "notification_notices" as notices_url %}{% blocktrans %}You have received the following notice from {{ current_site }}:
+{% load i18n %}{% url "notification_notice_settings" as notices_url %}{% blocktrans %}You have received the following notice from {{ current_site }}:
 
 {{ message }}
 
-To see other notices or change how you receive notifications, please go to {{ default_http_protocol }}://{{ current_site }}{{ notices_url }}
+To change how you receive notifications, please go to {{ default_http_protocol }}://{{ current_site }}{{ notices_url }}
 {% endblocktrans %}


### PR DESCRIPTION
The "notification_notices" url name no longer exists.

Since only "notification_notice_settings" is provided with the project now,
I added it to the default email template and changed the text in the template
to remove an indication of viewing the notices when changing the notification
settings