### PR TITLE
update documentation on notices creation for Django-1.7

### DIFF
--- a/pinax/notifications/migrations/0001_initial.py
+++ b/pinax/notifications/migrations/0001_initial.py
@@ -9,11 +9,12 @@ from django.conf import settings
 
 class Migration(migrations.Migration):
 
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
     if django.VERSION >= (1, 8, 0):
-        dependencies = [
-            ('contenttypes', '0002_remove_content_type_name'),
-            migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ]
+        dependencies.insert(0,
+            ('contenttypes', '0002_remove_content_type_name'))
 
     operations = [
         migrations.CreateModel(


### PR DESCRIPTION
I think that the current documentation on notices creation is outdated, since Django-1.7 deprecated `post_syncdb`, and the example does not work, because the signal is not emitted.
I have written a different way to call the function that creates the notices.