### PR TITLE
fix migration error issue #48

### DIFF
--- a/pinax/notifications/migrations/0001_initial.py
+++ b/pinax/notifications/migrations/0001_initial.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('contenttypes', '__latest__'),
     ]
     if django.VERSION >= (1, 8, 0):
         dependencies.insert(0,


### PR DESCRIPTION
following the suggestions in https://github.com/pinax/pinax-notifications/issues/48 i created this PR that appears to have fixed my `ValueError: Lookup failed for model referenced by field notifications.NoticeSetting.scoping_content_type: contenttypes.ContentType` using Django 1.7.x and pinax-notifications 3.0.0