### PR TITLE
Fix template rendering for compatibility with Django 1.10+

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,24 @@
 
 _*BI*_ = backward incompatible change
 
+## 3.0.1
+* initial support for Django 1.10
+
+
+## 3.0
+* fix compatability with Django migrations
+
+
+## 2.1.0
+* add Django migrations
+
+
+## 2.0
+
+* renamed app as pinax-notifications
+* added the ability to override NoticeSetting model
+* added documentation on scoping notifications
+
 
 ## 1.1.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ _*BI*_ = backward incompatible change
 
 ## 4.0
 * _*BI*_: To support changes to `render_to_string` in Django 1.10 and above,
-plain text templates must now be autoescaped explicitly using the
+your notice `full.txt` and `short.txt` plain text templates must now be autoescaped explicitly using the
 `{% autoescape %}` tag.
 ([#68](https://github.com/pinax/pinax-notifications/issues/68#issuecomment-258383323)) 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 _*BI*_ = backward incompatible change
 
+## 4.0
+* _*BI*_: To support changes to `render_to_string` in Django 1.10 and above,
+plain text templates must now be autoescaped explicitly using the
+`{% autoescape %}` tag.
+([#68](https://github.com/pinax/pinax-notifications/issues/68#issuecomment-258383323)) 
+
+
 ## 3.0.1
 * initial support for Django 1.10
 

--- a/pinax/notifications/backends/base.py
+++ b/pinax/notifications/backends/base.py
@@ -1,4 +1,3 @@
-from django.template import Context
 from django.template.loader import render_to_string
 
 from django.contrib.sites.models import Site
@@ -36,9 +35,6 @@ class BaseBackend(object):
         """
         format_templates = {}
         for fmt in formats:
-            # conditionally turn off autoescaping for .txt extensions in format
-            if fmt.endswith(".txt"):
-                context.autoescape = False
             format_templates[fmt] = render_to_string((
                 "pinax/notifications/{0}/{1}".format(label, fmt),
                 "pinax/notifications/{0}".format(fmt)), context)
@@ -49,8 +45,8 @@ class BaseBackend(object):
         default_http_protocol = "https" if use_ssl else "http"
         current_site = Site.objects.get_current()
         base_url = "{0}://{1}".format(default_http_protocol, current_site.domain)
-        return Context({
+        return {
             "default_http_protocol": default_http_protocol,
             "current_site": current_site,
             "base_url": base_url
-        })
+        }

--- a/pinax/notifications/backends/email.py
+++ b/pinax/notifications/backends/email.py
@@ -32,12 +32,12 @@ class EmailBackend(BaseBackend):
         ), notice_type.label, context)
 
         context.update({
-            "messages": messages["short.txt"],
+            "message": messages["short.txt"],
         })
         subject = "".join(render_to_string("pinax/notifications/email_subject.txt", context).splitlines())
 
         context.update({
-            "messages": messages["full.txt"]
+            "message": messages["full.txt"]
         })
         body = render_to_string("pinax/notifications/email_body.txt", context)
 

--- a/pinax/notifications/backends/email.py
+++ b/pinax/notifications/backends/email.py
@@ -31,12 +31,14 @@ class EmailBackend(BaseBackend):
             "full.txt"
         ), notice_type.label, context)
 
-        subject = "".join(render_to_string("pinax/notifications/email_subject.txt", {
-            "message": messages["short.txt"],
-        }, context).splitlines())
+        context.update({
+            "messages": messages["short.txt"],
+        })
+        subject = "".join(render_to_string("pinax/notifications/email_subject.txt", context).splitlines())
 
-        body = render_to_string("pinax/notifications/email_body.txt", {
-            "message": messages["full.txt"],
-        }, context)
+        context.update({
+            "messages": messages["full.txt"]
+        })
+        body = render_to_string("pinax/notifications/email_body.txt", context)
 
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [recipient.email])

--- a/pinax/notifications/templates/pinax/notifications/full.txt
+++ b/pinax/notifications/templates/pinax/notifications/full.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% autoescape off %}{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}{% endautoescape %}

--- a/pinax/notifications/templates/pinax/notifications/short.txt
+++ b/pinax/notifications/templates/pinax/notifications/short.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}
+{% autoescape off %}{% load i18n %}{% blocktrans %}{{ notice }}{% endblocktrans %}{% endautoescape %}

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,17 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.9,master},
-    py33-{1.8},
-    py34-{1.8,1.9,master},
-    py35-{1.8,1.9,master}
+    py27-{1.8,1.9,1.10,master},
+    py34-{1.8,1.9,1.10,master},
+    py35-{1.8,1.9,1.10,master}
 
 [testenv]
 deps =
-    coverage == 4.0.2
-    flake8 == 2.5.0
+    py{27,33,34,35}: coverage==4.0.2
+    flake8==2.5.0
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =


### PR DESCRIPTION
* Update test matrix for Django 1.8, 1.9, 1.10 and master
* Fix template deprecations in 1.8, 1.9 and incompatibility in Django 1.10 and up
* Note that the template fix is backwards incompatible; any plain text templates must now invoke `autoescape off` explicitly
* Backfill changelog for prior releases