### PR TITLE
Update models.py

### DIFF
--- a/pinax/notifications/models.py
+++ b/pinax/notifications/models.py
@@ -7,7 +7,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils.translation import activate, get_language
-from django.utils.translation import ugettext_lazy as _
+# from django.utils.translation import ugettext_lazy as _  # this form of translation is deprecated
+from django.utils.translation import gettext_lazy as _ # This is more compatible with django 4.00
 
 from .conf import settings
 from .hooks import hookset


### PR DESCRIPTION
Lazy translation like:  from django.utils.translation import ugettext_lazy as _  # this form of translation is deprecated and not compatible with django 4.00
.I have then replaced the line withe correct import.
Thanks.

Closes # .

Changes proposed in this PR:

-
-

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated
* You have added your name to the `AUTHORS` file

