### PR TITLE
Update apps.py

### DIFF
--- a/pinax/notifications/apps.py
+++ b/pinax/notifications/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.translation import ugettext_lazy as _
+# from django.utils.translation import ugettext_lazy as _ # This line deprecated
+from django.utils.translation import gettext_lazy as _
 
 
 class AppConfig(BaseAppConfig):


### PR DESCRIPTION
 from django.utils.translation import ugettext_lazy as _ # This line deprecated and not compatible with django4 and python 3.10

I have proposed the current compatible import from the django documentation.

Closes # .

Changes proposed in this PR:

-
-

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated
* You have added your name to the `AUTHORS` file

