### PR TITLE
resolve django3.2 deprecation issues

### DIFF
--- a/pinax/notifications/__init__.py
+++ b/pinax/notifications/__init__.py
@@ -1,4 +1,6 @@
 import pkg_resources
+import django
 
-default_app_config = "pinax.notifications.apps.AppConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "pinax.notifications.apps.AppConfig"
 __version__ = pkg_resources.get_distribution("pinax-notifications").version

--- a/pinax/notifications/apps.py
+++ b/pinax/notifications/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AppConfig(BaseAppConfig):

--- a/pinax/notifications/backends/email.py
+++ b/pinax/notifications/backends/email.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 
 from .base import BaseBackend
 
@@ -22,7 +22,7 @@ class EmailBackend(BaseBackend):
         context.update({
             "recipient": recipient,
             "sender": sender,
-            "notice": ugettext(notice_type.display),
+            "notice": gettext(notice_type.display),
         })
         context.update(extra_context)
 

--- a/pinax/notifications/models.py
+++ b/pinax/notifications/models.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.query import QuerySet
 from django.utils.translation import activate, get_language
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .conf import settings
 from .hooks import hookset

--- a/pinax/notifications/tests/urls.py
+++ b/pinax/notifications/tests/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 urlpatterns = [
-    url(r"^notifications/", include("pinax.notifications.urls", namespace="pinax_notifications")),
+    path("notifications/", include("pinax.notifications.urls", namespace="pinax_notifications")),
 ]

--- a/pinax/notifications/urls.py
+++ b/pinax/notifications/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .views import NoticeSettingsView
 
 app_name = "pinax_notifications"
 
 urlpatterns = [
-    url(r"^settings/$", NoticeSettingsView.as_view(), name="notice_settings"),
+    path("settings/", NoticeSettingsView.as_view(), name="notice_settings"),
 ]

--- a/runtests.py
+++ b/runtests.py
@@ -47,7 +47,8 @@ DEFAULT_SETTINGS = dict(
                 ],
             },
         },
-    ]
+    ],
+    DEFAULT_AUTO_FIELD='django.db.models.BigAutoField',
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ show_missing = True
 [tox]
 envlist =
     checkqa,
-    py{36,37,38}-dj{22,30}
+    py{37,38,39}-dj{22,32}
    
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
@@ -36,7 +36,7 @@ deps =
     coverage<5
     codecov
     dj22: Django>=2.2,<3.0
-    dj30: Django>=3.0,<3.1
+    dj32: Django>=3.2,<3.3
     master: https://github.com/django/django/tarball/master
 
 usedevelop = True


### PR DESCRIPTION
Closes #103.

Changes proposed in this PR:

 - fix deprecation issues for django3.2  (including features to be dropped in django4.0);
 - add tox tests for versions python3.9 and django3.2, remove unsupported versions: python3.6 and django3.0
